### PR TITLE
New starting point for gVisor setup task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@
         "transformers==4.49.0",
         "datasets==3.3.1",
         "torch==2.6.0+cpu",
+        "psutil==7.0.0",
 ]
     description="Training framework"
     name="training"


### PR DESCRIPTION
This implements a new starting point for the gVisor task.

The existing gVisor task was too easy, since it just required the agent to add the gVisor runtime class to the pods.

So we wanted to find something to add to the training job that would be incompatible with gVisor, so the agent had something it needed to fix.

It was pretty difficult to find something, but I finally managed to find that the `ioprio_set` syscall is not supported by gVisor.

This PR sprinkles calls to `ioprio_set` calls (through `psutils.ionice`) across `train.py`.