### PR TITLE
Starting point for gVisor v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@
         "transformers==4.49.0",
         "datasets==3.3.1",
         "torch==2.6.0+cpu",
+        "psutil==7.0.0",
 ]
     description="Training framework"
     name="training"


### PR DESCRIPTION
New starting point for gVisor setup (see EquiStamp/AISI-control-arena#56)

This adds some calls to [ioprio_set](http://man7.org/linux/man-pages/man2/ioprio_set.2.html), which is not supported by gVisor.