### PR TITLE
have rbac teams use external secrets

### DIFF
--- a/{{cookiecutter.project_slug}}/overlays/external_secrets/training-infra/templates/team-credentials-secret.yaml
+++ b/{{cookiecutter.project_slug}}/overlays/external_secrets/training-infra/templates/team-credentials-secret.yaml
@@ -1,0 +1,26 @@
+{% if cookiecutter.rbac %}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: team-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: SecretStore
+  target:
+    name: team-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: team-alpha-password
+      remoteRef:
+        key: training-infra/team-credentials
+        property: team-alpha-password
+    - secretKey: team-beta-password
+      remoteRef:
+        key: training-infra/team-credentials
+        property: team-beta-password
+  dataFrom:
+    - extract:
+        key: training-infra/team-credentials 
+{% endif %}

--- a/{{cookiecutter.project_slug}}/overlays/rbac/training-infra/templates/rbac-minio-setup.yaml
+++ b/{{cookiecutter.project_slug}}/overlays/rbac/training-infra/templates/rbac-minio-setup.yaml
@@ -68,8 +68,13 @@ spec:
               mc admin policy create myminio team-alpha-policy /tmp/team-alpha-policy.json
               mc admin policy create myminio team-beta-policy /tmp/team-beta-policy.json
               # Create MinIO users for each team
+{% if cookiecutter.external_secrets %}
+              mc admin user add myminio team-alpha $TEAM_ALPHA_PASSWORD
+              mc admin user add myminio team-beta $TEAM_BETA_PASSWORD
+{% else %}
               mc admin user add myminio team-alpha team-alpha-password
               mc admin user add myminio team-beta team-beta-password
+{% endif %}
               # Assign policies to users
               mc admin policy attach myminio team-alpha-policy --user team-alpha
               mc admin policy attach myminio team-beta-policy --user team-beta
@@ -86,6 +91,16 @@ spec:
                 secretKeyRef:
                   name: minio-credentials
                   key: minio-password
+            - name: TEAM_ALPHA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: team-credentials
+                  key: team-alpha-password
+            - name: TEAM_BETA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: team-credentials
+                  key: team-beta-password
     {% else %}
             - name: MINIO_ACCESS_KEY
               value: "minioadmin"


### PR DESCRIPTION
This makes the the RBAC setup more realistic if external secrets is set by not having hardcoded team passwords. Note of course, this requires `training-infra/team-credentials` to be externally set.

On a seperate note, I remember reading that they wanted more realistic names than team-alpha and team-beta. I would make this change, but I didn't want to overstep as I believe someone else is working on rbac improvements.