### PR TITLE
Keda config improvements 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deploy:
 
 wait_for_ray:
 	@echo "Waiting for Ray cluster head node to be ready..."
-	@POD_NAME=$$(kubectl get endpoints raycluster-${ENVIRONMENT}-head-svc -o jsonpath='{.subsets[0].addresses[0].targetRef.name}') && kubectl wait --for=condition=ready pod/$$POD_NAME --timeout=60s
+	@POD_NAME=$$(kubectl get endpoints raycluster-${ENVIRONMENT}-head-svc -o jsonpath='{.subsets[0].addresses[0].targetRef.name}') && kubectl wait --for=condition=ready pod/$$POD_NAME --timeout=120s
 
 start_port_forward: wait_for_ray
 	@echo "Starting port forwarding..."

--- a/training-infra/templates/buckets-creation.yaml
+++ b/training-infra/templates/buckets-creation.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: internal-buckets
-        image: localhost:5001/job:{{ .Values.environment }}
+        image: localhost:5001/job:latest
         imagePullPolicy: Always
         command:
         - /bin/bash

--- a/training-infra/templates/dataset_download.yaml
+++ b/training-infra/templates/dataset_download.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: dataset-sync
-        image: localhost:5001/job:{{ .Values.environment }}
+        image: localhost:5001/job:latest
         imagePullPolicy: Always
         command:
         - /bin/bash

--- a/training-infra/templates/training-cluster.yaml
+++ b/training-infra/templates/training-cluster.yaml
@@ -15,7 +15,7 @@ spec:
         containers:
           - name: ray-head
             # preloaded onto nodes
-            image: localhost:5001/training:{{ .Values.environment }}
+            image: localhost:5001/training:latest
             imagePullPolicy: Always
             ports:
               - containerPort: 6379
@@ -49,7 +49,7 @@ spec:
           containers:
             - name: ray-worker
               # preloaded onto nodes
-              image: localhost:5001/training:{{ .Values.environment }}
+              image: localhost:5001/training:latest
               imagePullPolicy: Always
               lifecycle:
                 preStop:

--- a/training-infra/templates/weights-download.yaml
+++ b/training-infra/templates/weights-download.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: model-sync
-        image: localhost:5001/job:{{ .Values.environment }}
+        image: localhost:5001/job:latest
         imagePullPolicy: Always
         command:
         - /bin/bash


### PR DESCRIPTION
# Summary
This is not supposed to be merged as it contains some debug code. The main purpose of this is to show better "wait_for_ray" version that doesn't lead into `code 2: error: arguments in resource/name form must have a single resource and name make: *** [Makefile:20: wait_for_ray] Error 1` that randomly occurs in eval runs.

## Changes
1. Aall image tags are changed to "latest" as I was experiencing random Image pull issues during deployment with original {{ .Values.environment }} tags - probably the tagging mechanism is sometimes slow
2. Adds a for loop that every 10 seconds checks if the POD_NAME is available, if it is it waits for 120s for the pod to be ready, otherwise keeps checking