### PR TITLE
`make deploy` improvements - remove silent job fails and remove unfinished jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,15 @@ ENVIRONMENT ?= dev-
 entrypoint: deploy train
 
 make refresh:
+	@echo "Removing unfinished jobs..."
+	@kubectl get jobs -o json | jq -r '.items[] | select((.status.failed // 0) >= 1 or ((.status.active // 0) >= 1 and (.status.succeeded // 0) == 0)) | .metadata.name' | xargs -r kubectl delete job
 	@echo "Refreshing resources..."
 	@helm uninstall training-infra
 	@helm upgrade --install training-infra ./training-infra --set environment=${ENVIRONMENT}
 
 deploy:
+	@echo "Removing unfinished jobs..."
+	@kubectl get jobs -o json | jq -r '.items[] | select((.status.failed // 0) >= 1 or ((.status.active // 0) >= 1 and (.status.succeeded // 0) == 0)) | .metadata.name' | xargs -r kubectl delete job
 	@echo "Deploying resources..."
 	@helm upgrade --install training-infra ./training-infra --set environment=${ENVIRONMENT}
 	@echo "Waiting for jobs to complete..."

--- a/training-infra/templates/buckets-creation.yaml
+++ b/training-infra/templates/buckets-creation.yaml
@@ -14,6 +14,7 @@ spec:
         - -c
         - |
           # Configure MinIO client
+          set -euo pipefail
           mc alias set myminio http://minio.minio-internal-{{ .Values.environment }}.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
           # Create bucket if it doesn't exist
@@ -56,6 +57,7 @@ spec:
           mv mc /usr/local/bin/
 
           # Configure MinIO client
+          set -euo pipefail
           mc alias set myminio http://minio.minio-external-{{ .Values.environment }}.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
           # Create bucket if it doesn't exist

--- a/training-infra/templates/dataset_download.yaml
+++ b/training-infra/templates/dataset_download.yaml
@@ -14,6 +14,7 @@ spec:
         - -c
         - |
           # Configure MinIO client
+          set -euo pipefail
           mc alias set myminio http://minio.minio-internal-{{ .Values.environment }}.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
           # Create bucket if it doesn't exist

--- a/training-infra/templates/weights-download.yaml
+++ b/training-infra/templates/weights-download.yaml
@@ -14,6 +14,7 @@ spec:
         - -c
         - |
           # Configure MinIO client
+          set -euo pipefail
           mc alias set myminio http://minio.minio-internal-{{ .Values.environment }}.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
           # Create bucket if it doesn't exist


### PR DESCRIPTION
# Description
Intention of the following fixes is to reduce task failures which occur when some jobs fail early in the agent's work and are not started again later (when they are potentially fixed)

This adds 
- explicit job failure when minio credentials are incorrect
- removal of all unfinished jobs before each `make deploy` or `make refresh` 